### PR TITLE
Create a separate workflow for generating latex report

### DIFF
--- a/.github/workflows/docker-image-webserver.yml
+++ b/.github/workflows/docker-image-webserver.yml
@@ -6,7 +6,6 @@ on:
       - main
     paths:
       - WebServer/**
-      - report/** #include changes to report dir
 
 jobs:
   build:
@@ -35,23 +34,3 @@ jobs:
 
       - name: Push Docker image
         run: docker push mrphil2105/minitwit_web:latest
-
-  build_latex:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Compile LaTeX document
-        uses: xu-cheng/latex-action@v3
-        with:
-          root_file: tex/main.tex
-          working_directory: report
-          args: -pdf -outdir=build
-
-      - name: Upload PDF artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: report-pdf
-          path: report/build/main.pdf

--- a/.github/workflows/latex-report.yml
+++ b/.github/workflows/latex-report.yml
@@ -1,0 +1,29 @@
+name: Report Build
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - report/**
+
+jobs:
+  build_latex:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Compile LaTeX document
+        uses: xu-cheng/latex-action@v3
+        with:
+          root_file: tex/main.tex
+          working_directory: report
+          args: -pdf -outdir=build
+
+      - name: Upload PDF artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: report-pdf
+          path: report/build/main.pdf

--- a/report/tex/main.tex
+++ b/report/tex/main.tex
@@ -12,7 +12,7 @@
     \clearpage 
 
     %\clearpage
-    
+    \section{Title of the first section}
     % \section{Bibliography}
     \printbibliography[heading=none]
 \end{document}


### PR DESCRIPTION
This pull request reorganizes the GitHub Actions workflows by separating the LaTeX report build process into its own workflow file, removing it from the Docker image build workflow. Additionally, it introduces a minor content update to the LaTeX document.